### PR TITLE
Mistake in if clause incl and excl tax

### DIFF
--- a/view/frontend/web/template/checkout/cart/totals/cashondelivery.html
+++ b/view/frontend/web/template/checkout/cart/totals/cashondelivery.html
@@ -1,6 +1,6 @@
 <!-- ko -->
 <!-- ko if: isSelected() -->
-    <!-- ko if: displayIncluding() -->
+    <!-- ko if: displayExcluding() -->
         <tr class="totals cashondelivery excl">
             <th class="mark" scope="row" data-bind="text: title + ' ' + excludingTaxMessage"></th>
             <td class="amount">
@@ -8,7 +8,7 @@
             </td>
         </tr>
     <!-- /ko -->
-    <!-- ko if: displayExcluding() -->
+    <!-- ko if: displayIncluding() -->
         <tr class="totals cashondelivery incl">
             <th class="mark" scope="row" data-bind="text: title + ' ' + includingTaxMessage"></th>
             <td class="amount">


### PR DESCRIPTION
In /view/frontend/web/template/checkout/cart/totals/cashondelivery.html there is a mistake in displaying the fee including and excluding tax. In the KO if clause the checked value is "Incl Tax" but displayed is "Excl Tax". Just a switch of the both if clauses should work fine.